### PR TITLE
Allow hyphenated placeholders

### DIFF
--- a/email_tool/backend/services/template_service.py
+++ b/email_tool/backend/services/template_service.py
@@ -35,8 +35,8 @@ class TemplateService:
         template = Template(project_id=project_id, marketing_group_id=marketing_group_id, filename=filename, content=content)
         template = await self.template_repository.create(db, template)
         
-        # Extract placeholder keys
-        keys = set(re.findall(r"{{\s*(\w+)\s*}}", content))
+        # Extract placeholder keys (allow hyphens)
+        keys = set(re.findall(r"{{\s*([\w-]+)\s*}}", content))
         
         # Create placeholders and auto-create tags
         created_tags = []

--- a/tests/test_template_service.py
+++ b/tests/test_template_service.py
@@ -1,0 +1,55 @@
+import sys
+import os
+import asyncio
+import pytest
+from datetime import datetime
+
+# Ensure package imports work
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from email_tool.backend.services.template_service import TemplateService
+from email_tool.backend.models.template import Template
+from email_tool.backend.models.placeholder import Placeholder
+
+class DummyProjectRepository:
+    async def get(self, db, project_id):
+        return object()
+
+class DummyTemplateRepository:
+    async def create(self, db, template):
+        return template
+
+class DummyPlaceholderRepository:
+    def __init__(self):
+        self.created = []
+
+    async def create(self, db, placeholder):
+        self.created.append(placeholder)
+        return placeholder
+
+class DummyTag:
+    def __init__(self, name, description):
+        self.id = 1
+        self.name = name
+        self.color = "#000000"
+        self.description = description
+        self.created_at = datetime.utcnow()
+
+class DummyTagService:
+    async def get_or_create_tag(self, db, name, description):
+        return DummyTag(name, description)
+
+@pytest.mark.asyncio
+async def test_upload_template_hyphenated_placeholders():
+    service = TemplateService()
+    service.project_repository = DummyProjectRepository()
+    service.template_repository = DummyTemplateRepository()
+    service.placeholder_repository = DummyPlaceholderRepository()
+    service.tag_service = DummyTagService()
+
+    html = "<p>{{first-name}}</p><div>{{last_name}}</div>"
+    template, keys, tags = await service.upload_template(None, 1, 1, "test.html", html)
+
+    assert set(keys) == {"first-name", "last_name"}
+    placeholder_keys = [p.key for p in service.placeholder_repository.created]
+    assert set(placeholder_keys) == {"first-name", "last_name"}


### PR DESCRIPTION
## Summary
- expand placeholder extraction regex to allow hyphenated names
- add a pytest test covering hyphenated placeholders

## Testing
- `pytest tests/test_template_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a19ce7288328826cd6c7ec9f059d