### PR TITLE
Store PlaywrightResult issues as JSON

### DIFF
--- a/email_tool/backend/migrations/versions/a9deaecb7996_playwrightresult_issues_json.py
+++ b/email_tool/backend/migrations/versions/a9deaecb7996_playwrightresult_issues_json.py
@@ -1,0 +1,39 @@
+"""Store issues as JSON in PlaywrightResult
+
+Revision ID: a9deaecb7996
+Revises: 64af9871a726
+Create Date: 2024-06-20 00:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a9deaecb7996'
+down_revision: Union[str, Sequence[str], None] = '64af9871a726'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column(
+        'playwright_result',
+        'issues',
+        type_=sa.JSON(),
+        existing_type=sa.Text(),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.alter_column(
+        'playwright_result',
+        'issues',
+        type_=sa.Text(),
+        existing_type=sa.JSON(),
+    )
+

--- a/email_tool/backend/models/playwright_result.py
+++ b/email_tool/backend/models/playwright_result.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, Boolean, Text, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, Boolean, DateTime, ForeignKey, JSON
 from sqlalchemy.orm import relationship
 from datetime import datetime
 from .base import Base
@@ -9,7 +9,7 @@ class PlaywrightResult(Base):
     id = Column(Integer, primary_key=True, index=True)
     generated_email_id = Column(Integer, ForeignKey('generated_email.id'))
     passed = Column(Boolean, default=False)
-    issues = Column(Text)
+    issues = Column(JSON)
     tested_at = Column(DateTime, default=datetime.utcnow)
 
     generated_email = relationship('GeneratedEmail', back_populates='test_result')

--- a/email_tool/backend/services/test_service.py
+++ b/email_tool/backend/services/test_service.py
@@ -30,7 +30,7 @@ class TestService:
                 PlaywrightResult(
                     generated_email_id=email.id,
                     passed=test_result['passed'],
-                    issues=str(test_result['issues']),
+                    issues=test_result['issues'],
                 )
             )
         await db.commit()


### PR DESCRIPTION
## Summary
- switch `PlaywrightResult.issues` from text to JSON
- save JSON data in `TestService`
- add Alembic migration for the new column type

## Testing
- `pip install -r requirements.txt`
- `pip install requests`
- `pytest -k nothing -q` *(fails: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_6869a1a4139c832880f82ca5cd90e6bc