### PR TITLE
Make API base URL configurable via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ Authentication: Simple token or internal SSO (TBD)
    npm install
    ```
 
-2. **Start the development server:**
+2. **Configure the API URL:** Create a `.env` file in `email_tool/frontend` and set:
+   ```env
+   REACT_APP_API_URL=http://localhost:8000
+   ```
+
+3. **Start the development server:**
    ```bash
    npm start
    ```

--- a/email_tool/frontend/src/config.ts
+++ b/email_tool/frontend/src/config.ts
@@ -1,5 +1,7 @@
 // API Configuration
-export const API_BASE_URL = 'http://localhost:8000';
+// Use environment variable if provided, otherwise default to local backend
+export const API_BASE_URL =
+  process.env.REACT_APP_API_URL || 'http://localhost:8000';
 
 // Helper function to build API URLs
 export const apiUrl = (endpoint: string): string => {


### PR DESCRIPTION
## Summary
- allow overriding the frontend API URL with `REACT_APP_API_URL`
- document how to set `REACT_APP_API_URL` using a `.env` file

## Testing
- `npm run build` in `email_tool/frontend`
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6869a214c5148328ad1f540b17bd0fbc