### PR TITLE
Update screenshot directory handling

### DIFF
--- a/email_tool/backend/main.py
+++ b/email_tool/backend/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 from .data_access.database import init_db, get_db
 from .routers import api
 from .services.marketing_group_service import MarketingGroupService
@@ -27,7 +28,13 @@ app.add_middleware(
 )
 
 # Serve static files (screenshots)
-app.mount("/static", StaticFiles(directory="email_tool/backend/static"), name="static")
+static_dir = Path(__file__).resolve().parent / "services" / "static"
+static_dir.mkdir(parents=True, exist_ok=True)
+app.mount(
+    "/static",
+    StaticFiles(directory=static_dir),
+    name="static",
+)
 
 @app.on_event("startup")
 async def startup_event():

--- a/email_tool/backend/services/email_service.py
+++ b/email_tool/backend/services/email_service.py
@@ -91,7 +91,10 @@ class EmailService:
                         guid = str(uuid.uuid4())
                         html_temp_path = f"/tmp/{guid}.html" if os.name != 'nt' else f"C:\\Windows\\Temp\\{guid}.html"
                         screenshot_filename = f"{guid}.png"
-                        screenshot_path = os.path.join("email_tool/backend/static/screenshots", screenshot_filename)
+                        screenshot_path = os.path.join(
+                            Path(__file__).resolve().parent / 'static' / 'screenshots',
+                            screenshot_filename,
+                        )
                         screenshot_url = f"/static/screenshots/{screenshot_filename}"
                         # Write HTML to temp file
                         with open(html_temp_path, 'w', encoding='utf-8') as f:

--- a/email_tool/backend/services/template_render_service.py
+++ b/email_tool/backend/services/template_render_service.py
@@ -12,7 +12,8 @@ from ..data_access.placeholder_repository import PlaceholderRepository
 
 class TemplateRenderService:
     def __init__(self):
-        self.screenshots_dir = Path("static/screenshots")
+        # Store screenshots alongside backend static assets
+        self.screenshots_dir = Path(__file__).resolve().parent / 'static' / 'screenshots'
         self.screenshots_dir.mkdir(parents=True, exist_ok=True)
         self.template_repository = TemplateRepository()
         self.placeholder_repository = PlaceholderRepository()

--- a/email_tool/backend/services/template_service.py
+++ b/email_tool/backend/services/template_service.py
@@ -70,7 +70,8 @@ class TemplateService:
         
         # Convert to list of dictionaries with placeholders
         template_list = []
-        screenshots_dir = Path("static/screenshots")
+        # Locate screenshots in the backend static directory
+        screenshots_dir = Path(__file__).resolve().parent / 'static' / 'screenshots'
         
         for template in templates:
             template_id = getattr(template, 'id')

--- a/email_tool/backend/services/test_builder_service.py
+++ b/email_tool/backend/services/test_builder_service.py
@@ -246,7 +246,9 @@ class TestBuilderService:
             logs.append(f"Temporary HTML file created: {temp_html_path}")
 
             # Compute absolute screenshots directory
-            screenshots_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../static/screenshots'))
+            screenshots_dir = os.path.abspath(
+                os.path.join(os.path.dirname(__file__), 'static/screenshots')
+            )
             os.makedirs(screenshots_dir, exist_ok=True)
 
             # Run test using Playwright directly


### PR DESCRIPTION
## Summary
- compute screenshot directory based on the service module path
- ensure TemplateService and email generation use this directory
- mount new static directory in `main.py`
- adjust test builder to write screenshots here

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_6869a2130b0483288abcc8e7864e10d1